### PR TITLE
Adds ability to override site packages directory for install-bootstrap

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -131,7 +131,7 @@ def _uninstall_bootstrap():
     print("The pre-interpreter hook files has been uninstalled.")
 
 
-def _install_bootstrap():
+def _install_bootstrap(override_site_packages_dir=None):
     # add zzz_bootstrap.pth to site-packages dir for the init code. This is to
     # run code at pre-interpreter startup. This is especially needed for 'blackfire run'
     # cmd as we will enable profiler if BLACKFIRE_QUERY is in env. vars. There seems to be
@@ -143,9 +143,17 @@ def _install_bootstrap():
     # to the orig. sitecustomize on uninstall. So, the second way is cleaner
     # at least for uninstall operations. There are also other libs choosing this
     # approach. See: https://nedbatchelder.com/blog/201001/running_code_at_python_startup.html
+    # 
+    # 
+    # If override_site_packages_dir is set to a string, use this directory instead of the default one reported by the system.
+    # Useful in special cases and special configurations.
     site_packages_dir = None
     try:
-        site_packages_dir = get_python_lib()
+        if override_site_packages_dir and isinstance(override_site_packages_dir, str):
+            site_packages_dir = override_site_packages_dir
+        else:
+            site_packages_dir = get_python_lib()
+
         # generate the .pth file to be loaded at startup
         bootstrap_pth_file = os.path.join(
             site_packages_dir, 'zzz_blackfire_bootstrap.pth'

--- a/__init__.py
+++ b/__init__.py
@@ -118,10 +118,10 @@ atexit.register(_stop_at_exit)
 
 def _uninstall_bootstrap(override_site_packages_dir=None):
     if override_site_packages_dir and isinstance(override_site_packages_dir, str):
-            site_packages_dir = override_site_packages_dir
-        else:
-            site_packages_dir = get_python_lib()
-            
+        site_packages_dir = override_site_packages_dir
+    else:
+        site_packages_dir = get_python_lib()
+
     bootstrap_pth_file = os.path.join(
         site_packages_dir, 'zzz_blackfire_bootstrap.pth'
     )

--- a/__init__.py
+++ b/__init__.py
@@ -116,8 +116,12 @@ def _stop_at_exit():
 atexit.register(_stop_at_exit)
 
 
-def _uninstall_bootstrap():
-    site_packages_dir = get_python_lib()
+def _uninstall_bootstrap(override_site_packages_dir=None):
+    if override_site_packages_dir and isinstance(override_site_packages_dir, str):
+            site_packages_dir = override_site_packages_dir
+        else:
+            site_packages_dir = get_python_lib()
+            
     bootstrap_pth_file = os.path.join(
         site_packages_dir, 'zzz_blackfire_bootstrap.pth'
     )

--- a/__main__.py
+++ b/__main__.py
@@ -3,32 +3,39 @@ import sys
 from distutils.sysconfig import get_python_lib
 from blackfire.utils import console_input
 from blackfire import _install_bootstrap, _uninstall_bootstrap
+import argparse
 
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="This command will [un]install Python pre-interpreter hook files. " \
+            "By installing this pre-interpreter hook, you will be able to use " \
+            "`blackfire run` without any change to your code. Learn more at https://blackfire.io/docs.")
+
+    parser.add_argument('operation', choices=['install-bootstrap', 'uninstall-bootstrap', 'hello-world'])    
+
+    return parser
 
 def hello_world():
     print(
         '\nHello! Please do not mess with this complex function. You are warned!\n'
     )
 
+options = get_parser().parse_args()
 
-if len(sys.argv) > 1:
-    cmd = sys.argv[1]
-    if cmd == 'install-bootstrap':
-        q = "This command will install Python pre-interpreter hook files in %s. " \
-            "By installing this pre-interpreter hook, you will be able to use " \
-            "`blackfire run` without any change to your code. Learn more at " \
-            "`https://blackfire.io/docs`.\n\nDo you confirm installation? [Y/n]: " % \
-            (get_python_lib())
-        r = console_input(q).lower().strip()
-        if not r or r == 'y':
-            _install_bootstrap()
-    elif cmd == 'uninstall-bootstrap':
-        q = "This command will uninstall Python pre-interpreter hook files." \
-            "\n\nDo you confirm? [y/N]: "
-        r = console_input(q).lower().strip()
-        if r == 'y':
-            _uninstall_bootstrap()
-    elif cmd == 'hello-world':
-        hello_world()
-    else:
-        raise Exception('There is no such command: (%s)' % (cmd))
+
+cmd = options.operation
+if cmd == 'install-bootstrap':
+    q = "Do you confirm installation? [Y/n]: " 
+    r = console_input(q).lower().strip()
+    if not r or r == 'y':
+        _install_bootstrap()
+elif cmd == 'uninstall-bootstrap':
+    q = "This command will uninstall Python pre-interpreter hook files." \
+        "\n\nDo you confirm? [y/N]: "
+    r = console_input(q).lower().strip()
+    if r == 'y':
+        _uninstall_bootstrap()
+elif cmd == 'hello-world':
+    hello_world()
+else:
+    raise Exception('There is no such command: (%s)' % (cmd))

--- a/__main__.py
+++ b/__main__.py
@@ -35,7 +35,7 @@ elif cmd == 'uninstall-bootstrap':
         "\n\nDo you confirm? [y/N]: "
     r = console_input(q).lower().strip()
     if r == 'y':
-        _uninstall_bootstrap(options.site_packages_dir)
+        _uninstall_bootstrap(override_site_packages_dir=options.site_packages_dir)
 elif cmd == 'hello-world':
     hello_world()
 else:

--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from distutils.sysconfig import get_python_lib
 from blackfire.utils import console_input
 from blackfire import _install_bootstrap, _uninstall_bootstrap
@@ -7,11 +6,13 @@ import argparse
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(description="This command will [un]install Python pre-interpreter hook files. " \
+    parser = argparse.ArgumentParser(description="This command will [un]install Python pre-interpreter hook files." \
             "By installing this pre-interpreter hook, you will be able to use " \
             "`blackfire run` without any change to your code. Learn more at https://blackfire.io/docs.")
 
-    parser.add_argument('operation', choices=['install-bootstrap', 'uninstall-bootstrap', 'hello-world'])    
+    parser.add_argument('operation', choices=['install-bootstrap', 'uninstall-bootstrap', 'hello-world'], help="Operation to perform.")    
+
+    parser.add_argument('--site-packages-dir', action='store', default=None, help="Overrides python's `get_python_lib()` reported directory for site-packages-dir installation.")
 
     return parser
 
@@ -28,13 +29,13 @@ if cmd == 'install-bootstrap':
     q = "Do you confirm installation? [Y/n]: " 
     r = console_input(q).lower().strip()
     if not r or r == 'y':
-        _install_bootstrap()
+        _install_bootstrap(override_site_packages_dir=options.site_packages_dir)
 elif cmd == 'uninstall-bootstrap':
     q = "This command will uninstall Python pre-interpreter hook files." \
         "\n\nDo you confirm? [y/N]: "
     r = console_input(q).lower().strip()
     if r == 'y':
-        _uninstall_bootstrap()
+        _uninstall_bootstrap(options.site_packages_dir)
 elif cmd == 'hello-world':
     hello_world()
 else:


### PR DESCRIPTION
What does this MR solves?
-  Better and more extensible way of handling arguments (manual parsing -> argparse)
- Allows for special and edge case configurations where the reported python's `site-package-dir` is not the desired target for installing the `.pth` file.

How does this MR solves the problem?
- Implements the `argparse` library to handle argument parsing via the command line when Blackfire is used as a module. I.e. `python -m blackfire <arguments>`.
- Allows for the end user to override the site package directory reported by python's `get_python_lib()`, which in some cases and configurations ignores or skips the `PYTHONUSERBASE` environment variable.

**Note:** Backwards compatibility to existing code **is** maintained.