### PR TITLE
Fix constants.python_pgo_flag()

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -61,9 +61,9 @@ class BlackfireConstants(object):
     @classmethod
     @_on_except()
     def python_pgo_flag(cls):
-        return '-fprofile-use' in _get_sys_config_params(
+        return '-fprofile-use' in " ".join(_get_sys_config_params(
             'PY_CFLAGS', 'PY_CFLAGS_NODIST'
-        )
+        ))
 
     @classmethod
     @_on_except()


### PR DESCRIPTION
As `constants._get_sys_config_params()` returns a list (item 0 is for `PY_CFLAGS` and item 1 is for `PY_CFLAGS_NODIST`), `constants.python_pgo_flag()` always returns `False`. This MR fixes the bug by using `" ".join()` and it can now detect `-fprofile-use`.